### PR TITLE
Allow the local cfg to be filtered by maven

### DIFF
--- a/dspace/src/main/assembly/assembly.xml
+++ b/dspace/src/main/assembly/assembly.xml
@@ -49,6 +49,7 @@
          <includes>
             <include>local.cfg</include>
          </includes>
+         <filtered>true</filtered>
       </fileSet>
       <!-- Copy necessary subdirectories to resulting directory -->
       <!-- First, copy over our configurations -->


### PR DESCRIPTION
Allow the local cfg to be filtered by maven. This way people who want to use maven profiles to manage different server setups can still use them.
There are no maven variables present by default so it shouldn't have an impact on the original workings (fully optional).