### PR TITLE
Catch exception from encrypted PDF instead of expecting to test for it.

### DIFF
--- a/dspace-api/src/main/java/org/dspace/app/mediafilter/PDFFilter.java
+++ b/dspace-api/src/main/java/org/dspace/app/mediafilter/PDFFilter.java
@@ -18,6 +18,7 @@ import java.io.Writer;
 
 import org.apache.logging.log4j.Logger;
 import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.encryption.InvalidPasswordException;
 import org.apache.pdfbox.text.PDFTextStripper;
 import org.dspace.content.Item;
 import org.dspace.core.ConfigurationManager;
@@ -94,11 +95,11 @@ public class PDFFilter extends MediaFilter {
 
             try {
                 pdfDoc = PDDocument.load(source);
-                if (pdfDoc.isEncrypted()) {
-                    log.error("PDF is encrypted. Cannot extract text (item: " + currentItem.getHandle() + ")");
-                    return null;
-                }
                 pts.writeText(pdfDoc, writer);
+            } catch (InvalidPasswordException ex) {
+                log.error("PDF is encrypted. Cannot extract text (item: {})",
+                    () -> currentItem.getHandle());
+                return null;
             } finally {
                 try {
                     if (pdfDoc != null) {


### PR DESCRIPTION
Tested on a single Item with two bitstreams:  an encrypted PDF and an unencrypted PDF.

Without:  InvalidPasswordException bubbles up to main and spits a stack trace.

With:
File: dspace-pdf-test-1-encrypted.pdf.txt
SKIPPED: bitstream 3048de0a-d299-4e3d-a383-7752ddf21e99 (item: 123456789/5) because filtering was unsuccessful
File: dspace-pdf-test-1-encrypted.pdf.jpg
SKIPPED: bitstream 3048de0a-d299-4e3d-a383-7752ddf21e99 (item: 123456789/5) because filtering was unsuccessful
File: dspace-pdf-test-1.pdf.txt
FILTERED: bitstream 1dee45ce-5b76-4555-ab34-44ae3c1c067c (item: 123456789/5) and created 'dspace-pdf-test-1.pdf.txt'
File: dspace-pdf-test-1.pdf.jpg
FILTERED: bitstream 1dee45ce-5b76-4555-ab34-44ae3c1c067c (item: 123456789/5) and created 'dspace-pdf-test-1.pdf.jpg'

Bitstreams derived from the unencrypted PDF look right:  flat text is correct and complete, thumbnail resembles the full-sized page.